### PR TITLE
Bugfix/orders integration

### DIFF
--- a/src/expressConfig.ts
+++ b/src/expressConfig.ts
@@ -41,7 +41,7 @@ app.use( '/account', routers.account )
 app.use( '/product', userCanAccessShop, routers.product )
 app.use( '/category', routers.category )
 app.use( '/bank', routers.bank )
-app.use( '/order', routers.order )
+app.use( '/order', userCanAccessShop, routers.order )
 
 // Middleware to catch 404 and forward to error handler
 app.use( notFountMiddleware )

--- a/src/repositories/orderRepository.ts
+++ b/src/repositories/orderRepository.ts
@@ -93,6 +93,6 @@ export const findOrderByShopId = async (shop_id: string): Promise<Order[] | null
         if (error instanceof MongoError || error instanceof Error)
             log(error.message, 'EVENT', `User Repository - ${getFunctionName()}`, 'ERROR')
 
-        return null
+        return []
     }
 }

--- a/src/repositories/orderRepository.ts
+++ b/src/repositories/orderRepository.ts
@@ -93,6 +93,6 @@ export const findOrderByShopId = async (shop_id: string): Promise<Order[] | null
         if (error instanceof MongoError || error instanceof Error)
             log(error.message, 'EVENT', `User Repository - ${getFunctionName()}`, 'ERROR')
 
-        return []
+        return null
     }
 }

--- a/src/services/orderService.ts
+++ b/src/services/orderService.ts
@@ -122,7 +122,7 @@ export const savNewOrder = async (shop_id: string, order: HUB2B_Order) => {
 
     const shop_orders = await findOrderByShopId(shop_id)
 
-    if (Array.isArray(shop_orders) && shop_orders.filter(_order => _order.order.reference.id == order.reference.id)) return
+    if (shop_orders!.filter(_order => _order!.order!.reference!.id == order!.reference!.id).length) return
 
     const newOrder = await newOrderHub2b({ order, shop_id })
 

--- a/src/services/orderService.ts
+++ b/src/services/orderService.ts
@@ -122,7 +122,7 @@ export const savNewOrder = async (shop_id: string, order: HUB2B_Order) => {
 
     const shop_orders = await findOrderByShopId(shop_id)
 
-    if (Array.isArray(shop_orders) && shop_orders.filter(_order => _order.order.reference.id == order.reference.id)) return
+    if (Array.isArray(shop_orders) && shop_orders!.filter(_order => _order!.order!.reference!.id == order!.reference!.id).length) return
 
     const newOrder = await newOrderHub2b({ order, shop_id })
 

--- a/src/services/orderService.ts
+++ b/src/services/orderService.ts
@@ -122,7 +122,7 @@ export const savNewOrder = async (shop_id: string, order: HUB2B_Order) => {
 
     const shop_orders = await findOrderByShopId(shop_id)
 
-    if (shop_orders!.filter(_order => _order!.order!.reference!.id == order!.reference!.id).length) return
+    if (Array.isArray(shop_orders) && shop_orders.filter(_order => _order.order.reference.id == order.reference.id)) return
 
     const newOrder = await newOrderHub2b({ order, shop_id })
 


### PR DESCRIPTION
Além do middleware que faltava na rota de pedidos, o `OrderService/saveNewOrder` não estava salvando novos pedidos durante a rotina de integração - ao menos, não consegui chegar no resultado esperado por aqui. 

Dá uma testada por aí também antes de mesclar (dropa o localhost.order no banco e roda a rotina de integração).