### PR TITLE
Ajuste na remoção de token vencido.

### DIFF
--- a/src/services/tokenService.ts
+++ b/src/services/tokenService.ts
@@ -2,12 +2,12 @@
 //      Token Service
 //
 
-import { User } from "../models/user"
 import { AccessToken } from "../models/token"
+import { User } from "../models/user"
 import { createAccessToken, deleteAccessToken, findAccessTokenByToken, retrieveAllAccessToken } from "../repositories/tokenRepository"
 import { log } from "../utils/loggerUtil"
 import { create_UUID, getFunctionName, nowInSeconds } from "../utils/util"
-import { deleteUser } from "./userService"
+import { deleteInactiveUser } from "./userService"
 
 const ONE_DAY_IN_SECONDS = 86400
 const TWO_DAYS_IN_SECONDS = 172800
@@ -81,7 +81,7 @@ export const deleteAllInvalid = async () => {
 
         if ( !isValid ) {
             removeAccessToken( token.token )
-            deleteUser( token.user_id )
+            deleteInactiveUser( token.user_id )
         }
     } )
 }

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -16,12 +16,12 @@ import { removeAccessToken, isTokenValid } from "./tokenService"
  * @param email
  * @param password
  */
-export const createUser = async ( email: string, password: string, role?: Role | undefined ): Promise<User | null> => {
+export const createUser = async (email: string, password: string, role?: Role | undefined): Promise<User | null> => {
 
-    password = await hashPassword( password )
+    password = await hashPassword(password)
 
-    if ( !password ) {
-        log( `Hashing Error`, 'EVENT', getFunctionName(), 'ERROR' )
+    if (!password) {
+        log(`Hashing Error`, 'EVENT', getFunctionName(), 'ERROR')
         return null
     }
 
@@ -34,16 +34,16 @@ export const createUser = async ( email: string, password: string, role?: Role |
         role: _role,
     }
 
-    const newUser = await createNewUser( user )
+    const newUser = await createNewUser(user)
 
-    if ( !newUser ) {
-        log( `Could not create new user ${ email }`, 'EVENT', getFunctionName(), 'ERROR' )
+    if (!newUser) {
+        log(`Could not create new user ${email}`, 'EVENT', getFunctionName(), 'ERROR')
         return null
     }
 
-    log( `User ${ newUser.email } has been created.`, 'EVENT', getFunctionName() )
+    log(`User ${newUser.email} has been created.`, 'EVENT', getFunctionName())
 
-    sendEmailToActiveAccount( newUser )
+    sendEmailToActiveAccount(newUser)
 
     return newUser
 }
@@ -54,17 +54,17 @@ export const createUser = async ( email: string, password: string, role?: Role |
  * @param email - email
  * @param username - username
  */
-export const findUser = async ( email?: string, username?: string ): Promise<User | null> => {
+export const findUser = async (email?: string, username?: string): Promise<User | null> => {
 
     let result = null
 
-    if ( !email || !username ) return result
+    if (!email || !username) return result
 
-    if ( email )
-        result = await findUserByEmail( email )
+    if (email)
+        result = await findUserByEmail(email)
 
-    else if ( username )
-        result = await findUserByUsername( username )
+    else if (username)
+        result = await findUserByUsername(username)
 
     return result
 }
@@ -74,12 +74,12 @@ export const findUser = async ( email?: string, username?: string ): Promise<Use
  *
  * @param username - username
  */
-export const findUserByUsername = async ( username: string ): Promise<User | null> => {
+export const findUserByUsername = async (username: string): Promise<User | null> => {
 
-    const user = await findOneUser( { username } )
+    const user = await findOneUser({ username })
 
-    user ? log( `User ${ username } has been found.`, 'EVENT', getFunctionName() )
-        : log( `Could not find user  ${ username }`, 'EVENT', getFunctionName() )
+    user ? log(`User ${username} has been found.`, 'EVENT', getFunctionName())
+        : log(`Could not find user  ${username}`, 'EVENT', getFunctionName())
 
     return user
 }
@@ -89,12 +89,12 @@ export const findUserByUsername = async ( username: string ): Promise<User | nul
  *
  * @param email - user email
  */
-export const findUserByEmail = async ( email: string ): Promise<User | null> => {
+export const findUserByEmail = async (email: string): Promise<User | null> => {
 
-    const user = await findOneUser( { email } )
+    const user = await findOneUser({ email })
 
-    user ? log( `User ${ email } has been found.`, 'EVENT', getFunctionName() )
-        : log( `Could not find user  ${ email }`, 'EVENT', getFunctionName() )
+    user ? log(`User ${email} has been found.`, 'EVENT', getFunctionName())
+        : log(`Could not find user  ${email}`, 'EVENT', getFunctionName())
 
     return user
 }
@@ -104,12 +104,12 @@ export const findUserByEmail = async ( email: string ): Promise<User | null> => 
  *
  * @param _id - user id
  */
-export const findById = async ( _id: string ): Promise<User | null> => {
+export const findById = async (_id: string): Promise<User | null> => {
 
-    const user = await findUserById( _id )
+    const user = await findUserById(_id)
 
-    user ? log( `User ${ _id } has been found.`, 'EVENT', getFunctionName() )
-        : log( `Could not find user  ${ _id }`, 'EVENT', getFunctionName() )
+    user ? log(`User ${_id} has been found.`, 'EVENT', getFunctionName())
+        : log(`Could not find user  ${_id}`, 'EVENT', getFunctionName())
 
     return user
 }
@@ -120,14 +120,14 @@ export const findById = async ( _id: string ): Promise<User | null> => {
  * @param _id           - user id
  * @param newPassword   - new password
  */
-export const newPassword = async ( _id: any, newPassword: string ): Promise<User | null> => {
+export const newPassword = async (_id: any, newPassword: string): Promise<User | null> => {
 
-    newPassword = await hashPassword( newPassword )
+    newPassword = await hashPassword(newPassword)
 
-    const user = await updatePassword( _id, newPassword )
+    const user = await updatePassword(_id, newPassword)
 
-    user ? log( `User ${ _id } password has been updated.`, 'EVENT', getFunctionName() )
-        : log( `Could not update ${ _id } password`, 'EVENT', getFunctionName() )
+    user ? log(`User ${_id} password has been updated.`, 'EVENT', getFunctionName())
+        : log(`Could not update ${_id} password`, 'EVENT', getFunctionName())
 
     return user
 }
@@ -138,17 +138,17 @@ export const newPassword = async ( _id: any, newPassword: string ): Promise<User
  * @param token 
  * @returns User activated
  */
-export const activateUser = async ( token: string ): Promise<User | null> => {
+export const activateUser = async (token: string): Promise<User | null> => {
 
-    const activationToken = await isTokenValid( token )
+    const activationToken = await isTokenValid(token)
 
-    if ( !activationToken ) return null
+    if (!activationToken) return null
 
-    const user = await enableUser( activationToken.user_id )
+    const user = await enableUser(activationToken.user_id)
 
-    if ( !user ) return null
+    if (!user) return null
 
-    removeAccessToken( token )
+    removeAccessToken(token)
 
     user.isActive = true
 
@@ -160,13 +160,33 @@ export const activateUser = async ( token: string ): Promise<User | null> => {
  * 
  * @param user_id
  */
-export const deleteUser = async ( user_id: string ): Promise<User | null> => {
+export const deleteUser = async (user_id: string): Promise<User | null> => {
 
-    const deleted = await deleteUserByID( user_id )
+    const deleted = await deleteUserByID(user_id)
 
     deleted
-        ? log( `User ${ user_id } deleted.`, 'EVENT', getFunctionName() )
-        : log( `Could not delete user.`, 'EVENT', getFunctionName(), 'ERROR' )
+        ? log(`User ${user_id} deleted.`, 'EVENT', getFunctionName())
+        : log(`Could not delete user.`, 'EVENT', getFunctionName(), 'ERROR')
+
+    return deleted
+}
+
+/**
+ * Delete inactive user
+ * 
+ * @param user_id
+ */
+export const deleteInactiveUser = async (user_id: string): Promise<User | null> => {
+
+    const user: User | null = await findUserById(user_id)
+
+    if (!user || user.isActive) return null
+
+    const deleted = await deleteUserByID(user_id)
+
+    deleted
+        ? log(`User ${user_id} deleted.`, 'EVENT', getFunctionName())
+        : log(`Could not delete user.`, 'EVENT', getFunctionName(), 'ERROR')
 
     return deleted
 }


### PR DESCRIPTION
A remoção de token de ativação não validava se o usuário estava ativo ao fazer a remoção.
Foi criado o método deleteInactiveUser onde verifica se o usuário é ativo antes de deletar, assim, deletando apenas usuários inativos E com token vencido.